### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/spotify/redux-location-state.svg?branch=master)](https://travis-ci.org/spotify/redux-location-state)
+
 # redux-location-state
 Utilities for reading & writing Redux store state to & from the URL
 
@@ -147,7 +149,7 @@ by default, if there is a query param update it will only replace the url (it wo
 p: {stateKey: 'foo', options: {shouldPush: true}}
 ```
 
-### delimiter 
+### delimiter
 
 this only applies to arrays and objects, but you can declare how you'd like to delimit your items. by default it is `-`, but it can be overwritten
 
@@ -175,7 +177,7 @@ if the config is
   p: {stateKey: 'foo', defaultValue: {}, type: 'object', options: {isFlags: true, }},
 }
 ```
-and the state is 
+and the state is
 ```javascript
 {
   '/': {


### PR DESCRIPTION
Setup travis-ci for running tests pre-merge and post-merge.

Runs tests against node 5,6,7,8

https://travis-ci.org/spotify/redux-location-state

Does this:
<img width="778" alt="screen shot 2017-08-04 at 8 37 03 am" src="https://user-images.githubusercontent.com/18503/28968876-210a3b2e-78f0-11e7-9c46-45d8a1a6e5d9.png">
