### PR TITLE
chore: add GitHub URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lodash": "^4.13.1"
   },
   "repository": {
-    "type": "git"
+    "type": "git",
+    "url": "git+https://github.com/spotify/redux-location-state.git"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
@@ -62,5 +63,9 @@
   "license": "Apache-2.0",
   "pre-commit": [
     "test"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/spotify/redux-location-state/issues"
+  },
+  "homepage": "https://github.com/spotify/redux-location-state#readme"
 }


### PR DESCRIPTION
So far the npm package does not link back to GitHub. This PR adds the needed links to lead other developers to the repository and bugtracker.