### PR TITLE
fix: locationReducer return reduced object without assign

### DIFF
--- a/src/createReduxLocationActions.js
+++ b/src/createReduxLocationActions.js
@@ -36,13 +36,13 @@ export function createReduxLocationActions(setupObject, locationToStateReducer, 
     reducersWithLocation: (() => {
       const locationReducer = (state, action) => {
         const {type, payload} = action;
-        
+
         if (!payload) {return state;}
         if (LOCATION_POP === type) {
           if (payload.search) {
             payload.query = parseQuery(setupObject, payload);
           }
-          return payload ? Object.assign({}, locationToStateReducer(state, payload)) : state;
+          return payload ? locationToStateReducer(state, payload) : state;
         }
         return state;
       };


### PR DESCRIPTION
reducersWithLocation returned function would create a new object with the values of locationToStateReducer using Object.assign

Since Object.assign is a shallow copy, the object would loose it's methods (eg: Immutable.js)

Removing Object.assign fixes it.