### PR TITLE
fix(helpers): do not destructively modify initialState.global

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,7 +64,9 @@ export function getMatchingDeclaredPath(initialState, location) {
 export function createObjectFromConfig(initialState, location) {
   if (!initialState) {return;}
   const declaredPath = getMatchingDeclaredPath(initialState, location);
-  return initialState.global ? Object.assign(initialState.global, (initialState[declaredPath] || {})) : initialState[declaredPath];
+  return initialState.global ?
+    Object.assign({}, initialState.global, (initialState[declaredPath] || {})) :
+    initialState[declaredPath];
 }
 
 export function getPath() {


### PR DESCRIPTION
Merging new content directly to initialState.global eventually puts
every pathConfig value under 'global' key, which is obviously not the
desired behaviour.