### PR TITLE
fix(stateToParams): encode parameters keys & values once, not twice

### DIFF
--- a/src/stateToParams.js
+++ b/src/stateToParams.js
@@ -39,9 +39,9 @@ export function stateToParams(initialState, currentState, location) {
      currentItemState = typeHandles[type].serialize(currentItemState, options);
     }
     // add new params to reduced object
-    prev[encodeURIComponent(curr)] = encodeURIComponent(currentItemState);
+    prev[curr] = currentItemState;
     //check if a shouldPush property has changed
-    if ((encodeURIComponent(currentItemState) !== query[encodeURIComponent(curr)]) && options.shouldPush) {
+    if ((currentItemState !== query[curr]) && options.shouldPush) {
       shouldPush = true;
     }
     return prev;


### PR DESCRIPTION
There is no need to encode paramter's key and value inside
stateToParams because it is encoded inside
helpers/createParamsString. Moreover, by doing so we create
double-encoded parameters, hence query string grows on every page
reload (% -> %25 -> %2525 -> ...).

Also, since now query is encoded only once, there is no need to encode
value from state and value from query before comparing, since query
comes already decoded from helpers/parseParams.