### PR TITLE
tune(): allow for param encoder/decoder customization

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,15 @@ const helperAccessors = {
   get: lodashGet,
   set: lodashSet,
   isEqual: lodashIsEqual,
+};
+
+let paramEncoder = encodeURIComponent;
+export let paramDecoder = decodeURIComponent;
+export function setParamEncoder(encoder) {
+  paramEncoder = encoder;
+}
+export function setParamDecoder(decoder) {
+  paramDecoder = decoder;
 }
 
 // Some Redux libraries need specific accessor functions and can't use lodash.
@@ -91,7 +100,7 @@ export function createParamsString(qp) {
     if (isNotDefined(valueString) || (Array.isArray(valueString) && !valueString.length)) {
       return prev;
     }
-    return [...prev, (`${encodeURIComponent(keyString)}=${encodeURIComponent(valueString)}`)];
+    return [...prev, (`${paramEncoder(keyString)}=${paramEncoder(valueString)}`)];
   }, []);
 
   return paramArray.length ? `?${paramArray.join('&')}` : '';
@@ -103,7 +112,7 @@ export function parseParams(query) {
         queryparam = queryparam.substr(1);
       }
       const split = queryparam.split('=');
-      prev[decodeURIComponent(split[0])] = decodeURIComponent(split[1]) || '';
+      prev[paramDecoder(split[0])] = paramDecoder(split[1]) || '';
       return prev;
     }, {})) || {};
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export {createReduxLocationActions} from './createReduxLocationActions';
 export {listenForHistoryChange} from './listenForHistoryChange';
+export {setParamDecoder, setParamEncoder} from './helpers';

--- a/src/typeHandles.js
+++ b/src/typeHandles.js
@@ -1,4 +1,5 @@
 import {OBJECT_KEY_DELIMITER} from './constants';
+import {paramDecoder} from "./helpers";
 
 export const typeHandles = {
   number: {
@@ -14,7 +15,7 @@ export const typeHandles = {
       return (options.keepOrder ? [...paramValue] : [...paramValue].sort()).join(options.delimiter || OBJECT_KEY_DELIMITER);
     },
     parse(paramValue, options) {
-      return decodeURIComponent(paramValue).split(options.delimiter || OBJECT_KEY_DELIMITER);
+      return paramDecoder(paramValue).split(options.delimiter || OBJECT_KEY_DELIMITER);
     }
   },
   bool: {
@@ -40,7 +41,7 @@ export const typeHandles = {
 
         // otherwise parse the object
         } else {
-          const allObjectValues = decodeURIComponent(paramValue).split(',');
+          const allObjectValues = paramDecoder(paramValue).split(',');
           // since it was serialized as an array, split by comma and check to see if there are simple values
           return allObjectValues.reduce((prev, curr) => {
             let [key, value] = curr.split(OBJECT_KEY_DELIMITER);
@@ -50,4 +51,4 @@ export const typeHandles = {
         }
     }
   }
-}
+};


### PR DESCRIPTION
Hard-coded encodeURIComponent & decodeURIComponent are not suitable for
every app purposes, e.g. '/' which is harmless inside query parameters
gets encoded into unreadable '%2F'. The latter makes filesystem paths
totally unreadable as query parameters.

The sensible approach to that problem is to allow clients to provide
custom encoder & encoder for query parameters.