### PR TITLE
fix(typeHandles): apply custom delimiter for objects

### DIFF
--- a/src/typeHandles.js
+++ b/src/typeHandles.js
@@ -25,9 +25,9 @@ export const typeHandles = {
   object: {
     serialize(paramValue, options) {
       if (options.isFlags) {
-          return Object.keys(paramValue).filter((item, index) => paramValue[item]).join(OBJECT_KEY_DELIMITER);
+          return Object.keys(paramValue).filter((item, index) => paramValue[item]).join(options.delimiter || OBJECT_KEY_DELIMITER);
         } else {
-          return Object.keys(paramValue).sort().map((item, index) => `${item}${OBJECT_KEY_DELIMITER}${paramValue[item]}`);
+          return Object.keys(paramValue).sort().map((item, index) => `${item}${options.delimiter || OBJECT_KEY_DELIMITER}${paramValue[item]}`);
         }
     },
     parse(paramValue, options) {
@@ -44,7 +44,7 @@ export const typeHandles = {
           const allObjectValues = paramDecoder(paramValue).split(',');
           // since it was serialized as an array, split by comma and check to see if there are simple values
           return allObjectValues.reduce((prev, curr) => {
-            let [key, value] = curr.split(OBJECT_KEY_DELIMITER);
+            let [key, value] = curr.split(options.delimiter || OBJECT_KEY_DELIMITER);
             prev[key] = value;
             return prev;
           }, {});

--- a/test/spec/typeHandles.spec.js
+++ b/test/spec/typeHandles.spec.js
@@ -72,5 +72,21 @@ describe('typeHandles functions', () => {
    it('should parse an object and return a object of true keys', () => {
      expect(object.parse('boo-buzz', {isFlags: true})).to.deep.equal({boo: true, buzz: true});
    });
+   it('should return a serialized object with a customized delimiter', () => {
+     const delimiter = '|';
+     expect(object.serialize(testObject, {delimiter})).to.deep.equal([`key${delimiter}true`, `test${delimiter}yes`]);
+   });
+   it('should parse a string with a customized delimiter', () => {
+     const delimiter = '|';
+     expect(object.parse(`key${delimiter}value,foo${delimiter}bar`, {delimiter})).to.deep.equal({key: 'value', foo: 'bar'});
+   });
+   it('should return a serialized object with a customized delimiter in the flags mode', () => {
+    const delimiter = '|';
+    expect(object.serialize({foo: true, bar: true}, {delimiter, isFlags: true})).to.equal(`foo${delimiter}bar`);
+   });
+   it('should parse a string with a customized delimiter in the flags mode', () => {
+    const delimiter = '|';
+    expect(object.parse(`foo|bar`, {delimiter, isFlags: true})).to.deep.equal({foo: true, bar: true});
+   });
  });
 });


### PR DESCRIPTION
I noticed that the `delimiter` option doesn't apply to the 'object' type. This change fixes it. I also added a few test cases to cover this issue.